### PR TITLE
Change regex for unquoted string in Tokenizer

### DIFF
--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -88,7 +88,7 @@ module Sie
       end
 
       def find_unquoted_string
-        scanner.scan(/\S+/)
+        scanner.scan(/[^}\s]+/)
       end
 
       def remove_unnecessary_escapes(match)

--- a/spec/unit/parser/tokenizer_spec.rb
+++ b/spec/unit/parser/tokenizer_spec.rb
@@ -34,6 +34,23 @@ describe Sie::Parser::Tokenizer do
     ])
   end
 
+  it "can parse metadata arrays without quotation marks nor spaces" do
+    tokenizer = Sie::Parser::Tokenizer.new('#TRANS 2400 {1 2} -200 20130101 "Foocorp expense"')
+    tokens = tokenizer.tokenize
+
+    expect(token_table_for(tokens)).to eq([
+      [ "EntryToken", "TRANS" ],
+      [ "StringToken", "2400" ],
+      [ "BeginArrayToken", "" ],
+      [ "StringToken", "1" ],
+      [ "StringToken", "2" ],
+      [ "EndArrayToken", "" ],
+      [ "StringToken", "-200" ],
+      [ "StringToken", "20130101" ],
+      [ "StringToken", "Foocorp expense" ],
+    ])
+  end
+
   it "handles escaped quotes in quoted strings" do
     tokenizer = Sie::Parser::Tokenizer.new('"String with \\" quote"')
     tokens = tokenizer.tokenize


### PR DESCRIPTION
Problem med SIE-filer, #TRANS-rader, med DIM/UNDERDIM där värdet både saknar situationstecken och space till `}`. Exempel: 
`{2 95}` fungerar ej. Värdet kommer bli `95}`, vilket leder till att array-avslut ej hittas och resten av raden kommer hamna i `objektlista`.
`{2 95 }` fungerar.
`{ 2 95 }` fungerar.
`{2 "95"}` fungerar.

Samtliga fyra verkar dock godkända sätt att skriva det på. Alla fyra varianterna går igenom test på https://sietest.sie.se

Denna PR är bara en ändring av regex vid sökande efter sträng. Tillagt att `}` ej skall tas med. Ett test för detta är även gjort.
